### PR TITLE
Rename "Watchers" to "Stargazers"

### DIFF
--- a/lib/list/template.html
+++ b/lib/list/template.html
@@ -9,7 +9,7 @@
         <td data-text='license'></td>
       </tr>
       <tr>
-        <td>Watchers</td>
+        <td>Stargazers</td>
         <td data-text='stars'></td>
       </tr>
       <tr>


### PR DESCRIPTION
Maybe we should stick to GitHub's naming conventions here?

Stargazers don't really 'watch' a repository. Merge, if you feel like it.

You could also merge PR #19, which renames _Watchers_ to _Stars_.
