### PR TITLE
extend debounce

### DIFF
--- a/lib/search/search.js
+++ b/lib/search/search.js
@@ -65,7 +65,7 @@ SearchView.prototype.search = function(e){
   this.timer = setTimeout(function(){
     self.timer = null;
     self.emit('query', e.target.value);
-  }, 100);
+  }, 300);
 };
 
 /**
@@ -75,7 +75,12 @@ SearchView.prototype.search = function(e){
  */
 
 SearchView.prototype.addSpinner = function(){
-  this.el.appendChild(this.spinner.el);
+  var el = el || document.getElementById(this.spinner.el.id);
+  if(!el){
+    this.el.appendChild(this.spinner.el);
+  }else {
+    this.spinner.el.style.display = "block";
+  }
 };
 
 /**
@@ -85,7 +90,7 @@ SearchView.prototype.addSpinner = function(){
  */
 
 SearchView.prototype.removeSpinner = function(){
-  this.el.removeChild(this.spinner.el);
+  this.spinner.el.style.display = "none";
 };
 
 /**


### PR DESCRIPTION
debounce timer in search.js is too short leading to unwanted requests and also affecting the toggle condition for the spinner canvas where browser spits out DOM exception error 8. So extended timer from 100 to 300 ms and instead of appending and removing the spinner each time just toggled the style.
